### PR TITLE
Storybook deploy

### DIFF
--- a/.deploy/index.html
+++ b/.deploy/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hands on with design systems workshop</title>
+  </head>
+  <body>
+    <h2>Find deployed workspaces here:</h2>
+    <ul>
+      <li>
+        <a href="./design-system">Design system</a>
+      </li>
+      <li>
+        <a href="./product">Product</a>
+      </li>
+    </ul>
+  </body>
+</html>

--- a/.github/workflows/design-system-release.yml
+++ b/.github/workflows/design-system-release.yml
@@ -1,4 +1,4 @@
-name: Storybook
+name: Design System
 on:
   push:
     branches:
@@ -42,12 +42,12 @@ jobs:
 
       - name: Cache dependencies
         uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        id: yrn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yrn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yrn-
+            ${{ runner.os }}-yarn-
           
       - name: Install dependencies
         run: |
@@ -58,14 +58,24 @@ jobs:
         run: |
           yarn tokens
           
-          
       - name: Build Storybook
         run: |
           yarn storybook:build
-          
+      
+      - name: Deploy Index file
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          folder: ./.deploy
+          branch: gh-pages      
+          clean: false
+
+      
       - name: Deploy Storybook
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
           folder: ./design-system/storybook-static
           branch: gh-pages
-          target-folder: storybook
+          target-folder: design-system
+          clean: true
+          clean-exclude: |
+            product

--- a/.github/workflows/design-system-release.yml
+++ b/.github/workflows/design-system-release.yml
@@ -1,9 +1,10 @@
-# This wqorkflow will be triggered every time when new version of library released
-name: Product release
+name: Storybook
 on:
   push:
     branches:
       - 'main'
+    paths:
+      - 'design-system/**'
 
 jobs:
   version-check:
@@ -21,12 +22,11 @@ jobs:
         uses: EndBug/version-check@v1
         with:
           diff-search: true
-          file-name: product/package.json
-
+          file-name: design-system/package.json
+          
   build-and-deploy:
-    needs: version-check
     runs-on: ubuntu-latest
-    if: needs.version-check.outputs.changed == 'true'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -45,20 +45,27 @@ jobs:
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-yrn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-
-
+            ${{ runner.os }}-yrn-
+          
       - name: Install dependencies
         run: |
           yarn install --frozen-lockfile
+        if: steps.yarn-cache.outputs.cache-hit != 'true'
 
-      - name: Build product
+      - name: Build design tokens
         run: |
-          yarn product:build
-
-      - name: Deploy product
+          yarn tokens
+          
+          
+      - name: Build Storybook
+        run: |
+          yarn storybook:build
+          
+      - name: Deploy Storybook
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
-          folder: ./product/build
+          folder: ./design-system/storybook-static
           branch: gh-pages
+          target-folder: storybook

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -1,0 +1,83 @@
+# This wqorkflow will be triggered every time when new version of library released
+name: Product release
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'product/**'
+
+jobs:
+  version-check:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.version-check.outputs.changed }}
+      version: ${{ steps.version-check.outputs.version }}
+      commit: ${{ steps.version-check.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - id: version-check
+        uses: EndBug/version-check@v1
+        with:
+          diff-search: true
+          file-name: product/package.json
+
+  build-and-deploy:
+    needs: version-check
+    runs-on: ubuntu-latest
+    if: needs.version-check.outputs.changed == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install NodeJS
+        uses: actions/setup-node@v2
+        with:
+          node-version: "12.18.2"
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: |
+          yarn install --frozen-lockfile
+
+      - name: Build product
+        run: |
+          yarn product:build
+
+      - name: Deploy product
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          folder: ./product/build
+          branch: gh-pages
+          
+      ## The following steps are for storybook deployment. Since we host product in the root, storybook will be overwritten every time we deploy a product. With these steps we restore it back
+      - name: Build design tokens
+        run: |
+          yarn tokens
+          
+      - name: Build Storybook
+        run: |
+          yarn storybook:build
+          
+      - name: Deploy Storybook
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          folder: ./design-system/storybook-static
+          branch: gh-pages
+          target-folder: storybook
+

--- a/.github/workflows/product-release.yml
+++ b/.github/workflows/product-release.yml
@@ -1,4 +1,3 @@
-# This wqorkflow will be triggered every time when new version of library released
 name: Product release
 on:
   push:
@@ -59,25 +58,19 @@ jobs:
         run: |
           yarn product:build
 
+      - name: Deploy Index file
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          folder: ./.deploy
+          clean: false
+          branch: gh-pages  
+          
       - name: Deploy product
         uses: JamesIves/github-pages-deploy-action@4.1.0
         with:
           folder: ./product/build
           branch: gh-pages
-          
-      ## The following steps are for storybook deployment. Since we host product in the root, storybook will be overwritten every time we deploy a product. With these steps we restore it back
-      - name: Build design tokens
-        run: |
-          yarn tokens
-          
-      - name: Build Storybook
-        run: |
-          yarn storybook:build
-          
-      - name: Deploy Storybook
-        uses: JamesIves/github-pages-deploy-action@4.1.0
-        with:
-          folder: ./design-system/storybook-static
-          branch: gh-pages
-          target-folder: storybook
-
+          target-folder: product
+          clean: true
+          clean-exclude: |
+            design-system

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "product": "yarn workspace product start",
     "product:build": "yarn workspace product build",
     "product:version": "yarn workspace product version",
-    "deploy": "yarn workspace product deploy"
+    "deploy:product": "gh-pages -d product/build && yarn deploy:storybook",
+    "deploy:storybook": "gh-pages -d design-system/storybook-static -e storybook"
   },
   "eslintIgnore": [
     "product",

--- a/product/package.json
+++ b/product/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "MIT",
+  "homepage": "https://goright-io.github.io/hands-on-design-system/product",
   "dependencies": {
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/product/package.json
+++ b/product/package.json
@@ -21,7 +21,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "predeploy": "yarn build",
+    "predeploy": "yarn build"
   },
   "eslintConfig": {
     "extends": [

--- a/product/package.json
+++ b/product/package.json
@@ -7,7 +7,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
-    "design-system": "0.1.0",
+    "design-system": "*",
     "gh-pages": "^3.1.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
@@ -22,7 +22,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "yarn build",
-    "deploy": "gh-pages -d build"
   },
   "eslintConfig": {
     "extends": [

--- a/product/src/pages/checkout.js
+++ b/product/src/pages/checkout.js
@@ -7,9 +7,11 @@ import styled from "styled-components";
 import { Button, Icon, Carousel, Select, colors } from "design-system";
 import { Link } from "react-router-dom";
 
-const card = "/images/card.svg";
-const cardBlue = "/images/cardBlue.svg";
-const cardPink = "/images/cardPink.svg";
+const imagesPath = `${process.env.PUBLIC_URL}/images`;
+
+const card = `${process.env.PUBLIC_URL}/images/card.svg`;
+const cardBlue = `${process.env.PUBLIC_URL}/images/cardBlue.svg`;
+const cardPink = `${process.env.PUBLIC_URL}/images/cardPink.svg`;
 
 const StyledDiv1 = styled.div`
   padding: 64px 40px 40px 40px;
@@ -69,11 +71,9 @@ const Checkout = () => {
     <div>
       <StyledDiv1>
         <StyledDiv2>
-          <Link to="/cart" style={{ textDecoration: "none" }}>
-            <Button isIcon color="white">
-              <Icon name="arrowBack" />
-            </Button>
-          </Link>
+          <Button as={Link} isIcon to="/cart/item1" color="white">
+            <Icon name="arrowBack" />
+          </Button>
           <StyledDiv3>
             <h4>Card</h4>
           </StyledDiv3>


### PR DESCRIPTION
Here comes new deployment system - we deploy product in the root, see example at `https://illustrova.github.io/ws-workflow-test/`, and storybook under the subpath: `https://illustrova.github.io/ws-workflow-test/storybook`.

This setup has few drawbacks (?) though.
1. I had to replace in product/package.json: 
```
-     "design-system": "0.1.0",
+     "design-system": "*",
```

I remember you didn't want this, but the thing is that the workflow fill fail every time the version doesn't match. Even if you are not working on product yet, and only want to deploy storybook, immediately after the design-system version is bumped, it has to match in product workspace. Seems yarn cannot install dependencies for selected workspace only. So either this, or to instruct participants to change it every time.

2. I have to redeploy storybook every time when product is deployed - this is unavoidable, if we like to host product in the root. For that reason I had to copy-paste part of storybook workflow into product workflow.  The best would probably be to rework all workflows, split into smaller parts and reuse, but didn't want to loose time on this now.
