### PR TITLE
move filter definition to main module

### DIFF
--- a/design-system/src/tokens/config.js
+++ b/design-system/src/tokens/config.js
@@ -17,33 +17,6 @@ StyleDictionary.registerTransform({
   },
 });
 
-/* Basic filter to separate typography tokens. It might need tweaking depending on the token data shape */
-StyleDictionary.registerFilter({
-  name: "isTypography",
-  matcher: function (prop) {
-    return (
-      [
-        'fontSize',
-        'textDecoration',
-        'fontFamily',
-        'fontWeight',
-        'fontStyle',
-        'fontStretch',
-        'fontStyleOld',
-        'letterSpacing',
-        'lineHeight',
-        'paragraphIndent',
-        'paragraphSpacing',
-        'textCase'
-      ].indexOf(prop.path[1]) !== -1
-    )
-    /* return (
-      prop.name.startsWith("headline") || prop.name.startsWith("paragraph")
-    );
-    */
-  },
-});
-
 module.exports = {
   source: ["./src/tokens/design-tokens.json"],
   platforms: {
@@ -57,7 +30,24 @@ module.exports = {
         {
           destination: "typography.js",
           format: "javascript/es6",
-          filter: "isTypography",
+          filter: function (prop) {
+            return (
+              [
+                "fontSize",
+                "textDecoration",
+                "fontFamily",
+                "fontWeight",
+                "fontStyle",
+                "fontStretch",
+                "fontStyleOld",
+                "letterSpacing",
+                "lineHeight",
+                "paragraphIndent",
+                "paragraphSpacing",
+                "textCase",
+              ].indexOf(prop.path[1]) !== -1
+            );
+          },
         },
         /* Filter and extract color tokens*/
         {


### PR DESCRIPTION
Natalia fixed yesterday her problem with tokens, and probably this fix won't affect anyone else, so we can change it for the whole repo.
Here is the explanation what finally worked: 

```
Natalia Davydova  11:19 PM
Я не знаю, почему, но, если в конфиге токенов прокинуть не строку (имя фильтра), а фильтрующую функцию, все запускается
он категорически не жрет строку, вот хоть как его, но просто ту же функцию из registerFilter съел и все скомпилил, как родной
```