### PR TITLE
upload creevey report on test failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Run Visual Regression test
         run: yarn test
       - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
         with:
           name: report
           path: design-system/tests/report/


### PR DESCRIPTION
Without this line the 'upload artifact' step is skipped on failure (which is when it's actually needed)